### PR TITLE
Add metadata-driven NFT listing workflow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,11 +139,20 @@ export default function RahabMintSite() {
                   erc20Address={"0x654f25F2a36997C397Aad8a66D5a8783b6E61b9b"}
                   tokenId={BigInt((starts[cat] ?? 1) + i)}
                   mediaUrl={metadata.image || metadata.animation_url}
-                  price={(metadata.price ?? "").toString().replace(/[^\d.]/g, "")}
+                  price={(metadata.price ?? "")
+                    .toString()
+                    .replace(/[^\d.]/g, "")}
                   category={cat}
                   fileName={fileName}
                   langStr="en-US"
                   initialSoldout={Boolean(metadata.soldout)}
+                  initialMintStatus={(metadata.mintStatus ?? "BeforeList") as string}
+                  ownerAddress={
+                    (metadata.ownerAddress ||
+                      metadata.owner ||
+                      metadata.walletAddress ||
+                      "") as string
+                  }
                 />
               </div>
             ))}

--- a/routes/metadata.js
+++ b/routes/metadata.js
@@ -5,6 +5,19 @@ const express = require("express");
 
 const router = express.Router();
 const METADATA_DIR = path.join(__dirname, "../metadata");
+const DEFAULT_MINT_STATUS = "BeforeList";
+
+function ensureMintStatus(data, filePath) {
+  if (!data.mintStatus) {
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch (err) {
+      console.error("Failed to persist default mintStatus", err);
+    }
+  }
+  return data;
+}
 
 router.get("/", (req, res) => {
   const result = {};
@@ -23,7 +36,10 @@ router.get("/", (req, res) => {
       for (const fileName of files) {
         const filePath = path.join(categoryPath, fileName);
         const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-        result[category].push({ fileName, metadata: content });
+        result[category].push({
+          fileName,
+          metadata: ensureMintStatus(content, filePath),
+        });
       }
     }
 
@@ -31,6 +47,72 @@ router.get("/", (req, res) => {
   } catch (err) {
     console.error("Error loading metadata:", err);
     res.status(500).json({ error: "Failed to load metadata" });
+  }
+});
+
+router.post("/updateListing", (req, res) => {
+  try {
+    const { category, fileName, mintStatus, price } = req.body || {};
+    if (!category || !fileName) {
+      res.status(400).json({ error: "category and fileName are required" });
+      return;
+    }
+
+    const filePath = path.join(METADATA_DIR, category, fileName);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "metadata file not found" });
+      return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+
+    if (typeof mintStatus === "string" && mintStatus.trim()) {
+      data.mintStatus = mintStatus.trim();
+    } else if (!data.mintStatus) {
+      data.mintStatus = DEFAULT_MINT_STATUS;
+    }
+
+    if (typeof price !== "undefined") {
+      const trimmed = typeof price === "string" ? price.trim() : "";
+      if (trimmed) {
+        data.price = trimmed;
+      } else {
+        delete data.price;
+      }
+    }
+
+    const payload = ensureMintStatus(data, filePath);
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+    res.json({ ok: true, metadata: payload });
+  } catch (err) {
+    console.error("Error updating listing:", err);
+    res.status(500).json({ error: "Failed to update metadata" });
+  }
+});
+
+router.post("/markSoldOut", (req, res) => {
+  try {
+    const { category, fileName } = req.body || {};
+    if (!category || !fileName) {
+      res.status(400).json({ error: "category and fileName are required" });
+      return;
+    }
+
+    const filePath = path.join(METADATA_DIR, category, fileName);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "metadata file not found" });
+      return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    data.soldout = true;
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    delete data.price;
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("Error marking sold out:", err);
+    res.status(500).json({ error: "Failed to update metadata" });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -15,6 +15,19 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 
 const METADATA_DIR = path.join(__dirname, "metadata");
+const DEFAULT_MINT_STATUS = "BeforeList";
+
+function ensureMintStatus(data, filePath) {
+  if (!data.mintStatus) {
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch (err) {
+      console.error("Failed to persist default mintStatus", err);
+    }
+  }
+  return data;
+}
 
 app.prepare().then(() => {
   const server = express();
@@ -33,10 +46,12 @@ app.prepare().then(() => {
         const files = fs.readdirSync(categoryPath).filter((f) => f.endsWith(".json"));
         result[category] = [];
         for (const fileName of files) {
-          const content = JSON.parse(
-            fs.readFileSync(path.join(categoryPath, fileName), "utf-8")
-          );
-          result[category].push({ fileName, metadata: content });
+          const filePath = path.join(categoryPath, fileName);
+          const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+          result[category].push({
+            fileName,
+            metadata: ensureMintStatus(content, filePath),
+          });
         }
       }
       res.json(result);
@@ -46,8 +61,47 @@ app.prepare().then(() => {
     }
   });
 
-  // === POST /api/markSoldOut ===
-  // body: { category: string, fileName: string }
+  // === POST /api/updateListing ===
+  // body: { category: string, fileName: string, mintStatus?: string, price?: string }
+  server.post("/api/updateListing", (req, res) => {
+    try {
+      const { category, fileName, mintStatus, price } = req.body || {};
+      if (!category || !fileName) {
+        res.status(400).json({ error: "category and fileName are required" });
+        return;
+      }
+      const filePath = path.join(METADATA_DIR, category, fileName);
+      if (!fs.existsSync(filePath)) {
+        res.status(404).json({ error: "metadata file not found" });
+        return;
+      }
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+
+      if (typeof mintStatus === "string" && mintStatus.trim()) {
+        data.mintStatus = mintStatus.trim();
+      } else if (!data.mintStatus) {
+        data.mintStatus = DEFAULT_MINT_STATUS;
+      }
+
+      if (typeof price !== "undefined") {
+        const trimmed = typeof price === "string" ? price.trim() : "";
+        if (trimmed) {
+          data.price = trimmed;
+        } else {
+          delete data.price;
+        }
+      }
+
+      const payload = ensureMintStatus(data, filePath);
+      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+      res.json({ ok: true, metadata: payload });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "Failed to update metadata" });
+    }
+  });
+
+  // Backwards compatibility: markSoldOut keeps updating soldout flag and resets listing state
   server.post("/api/markSoldOut", (req, res) => {
     try {
       const { category, fileName } = req.body || {};
@@ -62,6 +116,8 @@ app.prepare().then(() => {
       }
       const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
       data.soldout = true;
+      data.mintStatus = DEFAULT_MINT_STATUS;
+      delete data.price;
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
       res.json({ ok: true });
     } catch (e) {


### PR DESCRIPTION
## Summary
- expose metadata mint status, owner address, and listing price inputs in the PaymentNFT UI
- add an updateListing API endpoint and enforce default mintStatus when reading metadata
- keep existing routes compatible while resetting metadata after mint events

## Testing
- not run (next lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e06db5de3c83338dfdcffb2cf36a39