### PR TITLE
Enforce owner verification before listing NFTs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,11 +139,20 @@ export default function RahabMintSite() {
                   erc20Address={"0x654f25F2a36997C397Aad8a66D5a8783b6E61b9b"}
                   tokenId={BigInt((starts[cat] ?? 1) + i)}
                   mediaUrl={metadata.image || metadata.animation_url}
-                  price={(metadata.price ?? "").toString().replace(/[^\d.]/g, "")}
+                  price={(metadata.price ?? "")
+                    .toString()
+                    .replace(/[^\d.]/g, "")}
                   category={cat}
                   fileName={fileName}
                   langStr="en-US"
                   initialSoldout={Boolean(metadata.soldout)}
+                  initialMintStatus={(metadata.mintStatus ?? "BeforeList") as string}
+                  ownerAddress={
+                    (metadata.ownerAddress ||
+                      metadata.owner ||
+                      metadata.walletAddress ||
+                      "") as string
+                  }
                 />
               </div>
             ))}

--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -15,6 +15,8 @@ interface PaymentNFTProps {
   fileName: string;
   /** メタデータ由来の初期 soldout（オフチェーンフォールバック） */
   initialSoldout?: boolean;
+  initialMintStatus?: string;
+  ownerAddress?: string;
 }
 
 declare global {
@@ -126,6 +128,8 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     category,
     fileName,
     initialSoldout,
+    initialMintStatus,
+    ownerAddress,
   } = props;
 
   const [account, setAccount] = useState<string>("");
@@ -134,6 +138,28 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   const [isSoldOut, setIsSoldOut] = useState<boolean>(!!initialSoldout);
   const [erc20FromChain, setErc20FromChain] = useState<string>("");
   const [balance, setBalance] = useState<string>("");
+  const [mintStatus, setMintStatus] = useState<string>(
+    initialMintStatus || "BeforeList"
+  );
+  const [activePrice, setActivePrice] = useState<string>(price);
+  const [listPriceInput, setListPriceInput] = useState<string>(price);
+  const [updatingListing, setUpdatingListing] = useState<boolean>(false);
+  const [displayOwnerAddress, setDisplayOwnerAddress] = useState<string>(
+    ownerAddress || ""
+  );
+
+  useEffect(() => {
+    setMintStatus(initialMintStatus || "BeforeList");
+  }, [initialMintStatus]);
+
+  useEffect(() => {
+    setActivePrice(price);
+    setListPriceInput(price);
+  }, [price]);
+
+  useEffect(() => {
+    setDisplayOwnerAddress(ownerAddress || "");
+  }, [ownerAddress]);
   const explorerBase =
     process.env.NEXT_PUBLIC_PGIRLSCHAIN_EXPLORER ||
     "https://explorer.rahabpunkaholicgirls.com";
@@ -165,6 +191,11 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   /** ---------- On-chain + Off-chain soldout check ---------- */
   const checkSoldOut = useCallback(async () => {
     try {
+      if (mintStatus !== "Listed") {
+        setIsSoldOut(false);
+        return;
+      }
+
       if (initialSoldout) {
         setIsSoldOut(true);
         return;
@@ -188,7 +219,13 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     } catch {
       // keep previous
     }
-  }, [provider, nftContractAddr, tokenId, initialSoldout]);
+  }, [
+    provider,
+    nftContractAddr,
+    tokenId,
+    initialSoldout,
+    mintStatus,
+  ]);
 
   /** 初期化：アカウント取得 & soldout チェック */
   useEffect(() => {
@@ -223,7 +260,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
 
   /** ---------- Mint ---------- */
   const handleMint = useCallback(async () => {
-    if (minting || isSoldOut) return;
+    if (minting || isSoldOut || mintStatus !== "Listed") return;
     try {
       setMinting(true);
       setTxHash(null);
@@ -240,7 +277,12 @@ export default function PaymentNFT(props: PaymentNFTProps) {
         decimals = Number(await erc20.decimals());
       } catch {}
 
-      const parsedPrice = ethers.parseUnits((price ?? "0").toString(), decimals);
+      const priceValue = (activePrice || "").trim();
+      if (!priceValue) {
+        throw new Error("Listing price is missing");
+      }
+
+      const parsedPrice = ethers.parseUnits(priceValue, decimals);
       const ownerAddr = await signer.getAddress();
 
       const allowance: bigint = await erc20.allowance(ownerAddr, nftContractAddr);
@@ -259,8 +301,8 @@ export default function PaymentNFT(props: PaymentNFTProps) {
       const receipt = await tx.wait();
       setTxHash(receipt?.hash ?? tx.hash);
 
-      // ★ 即時反映：UI上で売切れにする
-      setIsSoldOut(true);
+      // ★ 即時反映：UI上で初期状態に戻す
+      setIsSoldOut(false);
 
       // 残高更新
       try {
@@ -270,17 +312,29 @@ export default function PaymentNFT(props: PaymentNFTProps) {
         setBalance(ethers.formatUnits(raw, d));
       } catch {}
 
-      // オンチェーン確認（保険）
-      await checkSoldOut();
-
       // ---- メタデータ側にも soldout を反映（フォールバック） ----
       try {
-        await fetch(`/api/markSoldOut`, {
+        const response = await fetch(`/api/updateListing`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ category, fileName }),
+          body: JSON.stringify({
+            category,
+            fileName,
+            mintStatus: "BeforeList",
+            price: "",
+          }),
         });
-      } catch {}
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body.error || "Failed to reset listing");
+        }
+      } catch (err) {
+        console.error(err);
+      }
+
+      setMintStatus("BeforeList");
+      setActivePrice("");
+      setListPriceInput("");
     } catch (e: any) {
       console.error(e);
       alert(e?.reason || e?.message || "Mint failed");
@@ -295,24 +349,191 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     erc20Address,
     erc20FromChain,
     nftContractAddr,
-    price,
+    activePrice,
     langStr,
     tokenId,
-    checkSoldOut,
     category,
     fileName,
+    mintStatus,
   ]);
 
-  const isDisabled = minting || isSoldOut;
+  const isDisabled =
+    minting || isSoldOut || mintStatus !== "Listed" || !activePrice?.trim();
+
+  const displayButtonLabel = isSoldOut
+    ? "Sold out"
+    : minting
+    ? "Processing..."
+    : mintStatus === "Listed"
+    ? "Mint with PGirls"
+    : "Not Listed";
+
+  const trimmedListPrice = (listPriceInput || "").trim();
+  const disableListingButton =
+    updatingListing ||
+    !trimmedListPrice ||
+    (mintStatus === "Listed" && trimmedListPrice === (activePrice || "").trim());
+
+  const handleListingUpdate = useCallback(async () => {
+    if (updatingListing || isSoldOut) return;
+    const sanitized = (listPriceInput || "").trim();
+    if (!sanitized) {
+      alert("Please input price before listing.");
+      return;
+    }
+    if (
+      mintStatus === "Listed" &&
+      sanitized === (activePrice || "").trim()
+    ) {
+      alert("Price is unchanged.");
+      return;
+    }
+    try {
+      setUpdatingListing(true);
+      if (!provider || !window.ethereum) {
+        alert("Wallet provider is required for listing.");
+        return;
+      }
+
+      await window.ethereum.request?.({ method: "eth_requestAccounts" });
+      const signer = await getSigner();
+      if (!signer) {
+        alert("Failed to get wallet signer.");
+        return;
+      }
+
+      const connectedAddress = (await signer.getAddress()) || "";
+      const normalizedConnected = connectedAddress.toLowerCase();
+      const normalizedOwner = (displayOwnerAddress || "").trim().toLowerCase();
+
+      if (normalizedOwner && normalizedOwner !== normalizedConnected) {
+        alert("Connected wallet does not match the owner address.");
+        return;
+      }
+
+      const response = await fetch(`/api/updateListing`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          category,
+          fileName,
+          mintStatus: "Listed",
+          price: sanitized,
+          ownerAddress:
+            (displayOwnerAddress || "").trim() || connectedAddress,
+        }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to update listing");
+      }
+      const body = await response.json().catch(() => ({}));
+      const updated = body?.metadata ?? {};
+      setMintStatus((updated.mintStatus as string) || "Listed");
+      const newPrice = (updated.price as string) || sanitized;
+      setActivePrice(newPrice);
+      setListPriceInput(newPrice);
+      if (updated.ownerAddress) {
+        setDisplayOwnerAddress(updated.ownerAddress as string);
+      } else {
+        setDisplayOwnerAddress(
+          (displayOwnerAddress || "").trim() || connectedAddress
+        );
+      }
+      setAccount(connectedAddress);
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.message || "Failed to update listing");
+    } finally {
+      setUpdatingListing(false);
+    }
+  }, [
+    updatingListing,
+    isSoldOut,
+    listPriceInput,
+    category,
+    fileName,
+    provider,
+    getSigner,
+    displayOwnerAddress,
+  ]);
+
+  const handlePriceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      const sanitized = value
+        .replace(/[^\d.]/g, "")
+        .replace(/(\..*)\./g, "$1");
+      setListPriceInput(sanitized);
+      if (mintStatus !== "Listed") {
+        setActivePrice(sanitized);
+      }
+    },
+    [mintStatus]
+  );
 
   return (
     <div style={{ textAlign: "center" }}>
       <AutoMedia providedUrl={mediaUrl} category={category} fileName={fileName} />
 
-      <p style={{ fontSize: "0.9rem", color: "#ccc" }}>Price: {price} PGirls</p>
+      <p style={{ fontSize: "0.9rem", color: "#ccc" }}>
+        Price: {activePrice ? `${activePrice} PGirls` : "-"}
+      </p>
       <p style={{ fontSize: "0.85rem", color: "#aaa" }}>
         Your PGirls balance (on-chain): {balance || "-"}
       </p>
+
+      <p style={{ fontSize: "0.85rem", color: "#aaa" }}>
+        Owner Address:{" "}
+        <span style={{ fontFamily: "monospace" }}>
+          {displayOwnerAddress || "-"}
+        </span>
+      </p>
+
+      {!isSoldOut && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            alignItems: "center",
+            marginTop: "0.75rem",
+          }}
+        >
+          <input
+            type="text"
+            inputMode="decimal"
+            value={listPriceInput}
+            onChange={handlePriceChange}
+            placeholder="Enter price in PGirls"
+            style={{
+              padding: "0.5rem",
+              borderRadius: "6px",
+              border: "1px solid #444",
+              background: "#111",
+              color: "#fff",
+              width: "200px",
+              textAlign: "center",
+            }}
+          />
+          <button
+            onClick={handleListingUpdate}
+            disabled={disableListingButton}
+            style={{
+              padding: "0.5rem 1rem",
+              backgroundColor:
+                disableListingButton ? "#444" : "#28a745",
+              color: "white",
+              border: "none",
+              borderRadius: "6px",
+              cursor:
+                disableListingButton ? "not-allowed" : "pointer",
+            }}
+          >
+            {mintStatus === "Listed" ? "Update Listing" : "List for Sale"}
+          </button>
+        </div>
+      )}
 
       <button
         onClick={handleMint}
@@ -327,7 +548,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
           cursor: isDisabled ? "not-allowed" : "pointer",
         }}
       >
-        {isSoldOut ? "Sold out" : minting ? "Processing..." : "Mint with PGirls"}
+        {displayButtonLabel}
       </button>
 
       {txHash && (

--- a/routes/metadata.js
+++ b/routes/metadata.js
@@ -5,6 +5,19 @@ const express = require("express");
 
 const router = express.Router();
 const METADATA_DIR = path.join(__dirname, "../metadata");
+const DEFAULT_MINT_STATUS = "BeforeList";
+
+function ensureMintStatus(data, filePath) {
+  if (!data.mintStatus) {
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch (err) {
+      console.error("Failed to persist default mintStatus", err);
+    }
+  }
+  return data;
+}
 
 router.get("/", (req, res) => {
   const result = {};
@@ -23,7 +36,10 @@ router.get("/", (req, res) => {
       for (const fileName of files) {
         const filePath = path.join(categoryPath, fileName);
         const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-        result[category].push({ fileName, metadata: content });
+        result[category].push({
+          fileName,
+          metadata: ensureMintStatus(content, filePath),
+        });
       }
     }
 
@@ -31,6 +47,80 @@ router.get("/", (req, res) => {
   } catch (err) {
     console.error("Error loading metadata:", err);
     res.status(500).json({ error: "Failed to load metadata" });
+  }
+});
+
+router.post("/updateListing", (req, res) => {
+  try {
+    const { category, fileName, mintStatus, price, ownerAddress } =
+      req.body || {};
+    if (!category || !fileName) {
+      res.status(400).json({ error: "category and fileName are required" });
+      return;
+    }
+
+    const filePath = path.join(METADATA_DIR, category, fileName);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "metadata file not found" });
+      return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+
+    if (typeof mintStatus === "string" && mintStatus.trim()) {
+      data.mintStatus = mintStatus.trim();
+    } else if (!data.mintStatus) {
+      data.mintStatus = DEFAULT_MINT_STATUS;
+    }
+
+    if (typeof price !== "undefined") {
+      const trimmed = typeof price === "string" ? price.trim() : "";
+      if (trimmed) {
+        data.price = trimmed;
+      } else {
+        delete data.price;
+      }
+    }
+
+    if (typeof ownerAddress === "string") {
+      const trimmedOwner = ownerAddress.trim();
+      if (trimmedOwner) {
+        data.ownerAddress = trimmedOwner;
+      }
+    }
+
+    const payload = ensureMintStatus(data, filePath);
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+    res.json({ ok: true, metadata: payload });
+  } catch (err) {
+    console.error("Error updating listing:", err);
+    res.status(500).json({ error: "Failed to update metadata" });
+  }
+});
+
+router.post("/markSoldOut", (req, res) => {
+  try {
+    const { category, fileName } = req.body || {};
+    if (!category || !fileName) {
+      res.status(400).json({ error: "category and fileName are required" });
+      return;
+    }
+
+    const filePath = path.join(METADATA_DIR, category, fileName);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "metadata file not found" });
+      return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    data.soldout = true;
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    delete data.price;
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("Error marking sold out:", err);
+    res.status(500).json({ error: "Failed to update metadata" });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -15,6 +15,19 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 
 const METADATA_DIR = path.join(__dirname, "metadata");
+const DEFAULT_MINT_STATUS = "BeforeList";
+
+function ensureMintStatus(data, filePath) {
+  if (!data.mintStatus) {
+    data.mintStatus = DEFAULT_MINT_STATUS;
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch (err) {
+      console.error("Failed to persist default mintStatus", err);
+    }
+  }
+  return data;
+}
 
 app.prepare().then(() => {
   const server = express();
@@ -33,10 +46,12 @@ app.prepare().then(() => {
         const files = fs.readdirSync(categoryPath).filter((f) => f.endsWith(".json"));
         result[category] = [];
         for (const fileName of files) {
-          const content = JSON.parse(
-            fs.readFileSync(path.join(categoryPath, fileName), "utf-8")
-          );
-          result[category].push({ fileName, metadata: content });
+          const filePath = path.join(categoryPath, fileName);
+          const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+          result[category].push({
+            fileName,
+            metadata: ensureMintStatus(content, filePath),
+          });
         }
       }
       res.json(result);
@@ -46,8 +61,55 @@ app.prepare().then(() => {
     }
   });
 
-  // === POST /api/markSoldOut ===
-  // body: { category: string, fileName: string }
+  // === POST /api/updateListing ===
+  // body: { category: string, fileName: string, mintStatus?: string, price?: string }
+  server.post("/api/updateListing", (req, res) => {
+    try {
+      const { category, fileName, mintStatus, price, ownerAddress } =
+        req.body || {};
+      if (!category || !fileName) {
+        res.status(400).json({ error: "category and fileName are required" });
+        return;
+      }
+      const filePath = path.join(METADATA_DIR, category, fileName);
+      if (!fs.existsSync(filePath)) {
+        res.status(404).json({ error: "metadata file not found" });
+        return;
+      }
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+
+      if (typeof mintStatus === "string" && mintStatus.trim()) {
+        data.mintStatus = mintStatus.trim();
+      } else if (!data.mintStatus) {
+        data.mintStatus = DEFAULT_MINT_STATUS;
+      }
+
+      if (typeof price !== "undefined") {
+        const trimmed = typeof price === "string" ? price.trim() : "";
+        if (trimmed) {
+          data.price = trimmed;
+        } else {
+          delete data.price;
+        }
+      }
+
+      if (typeof ownerAddress === "string") {
+        const trimmedOwner = ownerAddress.trim();
+        if (trimmedOwner) {
+          data.ownerAddress = trimmedOwner;
+        }
+      }
+
+      const payload = ensureMintStatus(data, filePath);
+      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+      res.json({ ok: true, metadata: payload });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "Failed to update metadata" });
+    }
+  });
+
+  // Backwards compatibility: markSoldOut keeps updating soldout flag and resets listing state
   server.post("/api/markSoldOut", (req, res) => {
     try {
       const { category, fileName } = req.body || {};
@@ -62,6 +124,8 @@ app.prepare().then(() => {
       }
       const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
       data.soldout = true;
+      data.mintStatus = DEFAULT_MINT_STATUS;
+      delete data.price;
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
       res.json({ ok: true });
     } catch (e) {


### PR DESCRIPTION
## Summary
- expose metadata mint status, owner address, and listing price inputs in the PaymentNFT UI
- add an updateListing API endpoint and enforce default mintStatus when reading metadata
- keep existing routes compatible while resetting metadata after mint events
- require the connected wallet to match the stored owner address before listing, persist owner updates, and reset the card UI to the unlisted state after mint

## Testing
- not run (lint command still prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e06db5de3c83338dfdcffb2cf36a39