### PR TITLE
Derive metadata owner address from private key

### DIFF
--- a/scripts/generateMetadata.cjs
+++ b/scripts/generateMetadata.cjs
@@ -1,10 +1,37 @@
 const fs = require("fs");
 const path = require("path");
+const { Wallet } = require("ethers");
 
 const ASSETS_DIR = path.join(__dirname, "../public/assets");
 const OUTPUT_DIR = path.join(__dirname, "../metadata");
 const BASE_URL = "https://mint.rahabpunkaholicgirls.com/assets";
-const DEFAULT_OWNER_ADDRESS = (process.env.METADATA_OWNER_ADDRESS || "").trim();
+const OWNER_PRIVATE_KEY = (process.env.METADATA_OWNER_PRIVATE_KEY || "").trim();
+
+function resolveOwnerAddressFromPrivateKey() {
+  if (!OWNER_PRIVATE_KEY) {
+    return "";
+  }
+
+  try {
+    const normalizedKey = OWNER_PRIVATE_KEY.startsWith("0x")
+      ? OWNER_PRIVATE_KEY
+      : `0x${OWNER_PRIVATE_KEY}`;
+    const wallet = new Wallet(normalizedKey);
+    return wallet.address;
+  } catch (err) {
+    console.warn("[metadata] Failed to derive owner address from private key:", err);
+    return "";
+  }
+}
+
+const DEFAULT_OWNER_ADDRESS = resolveOwnerAddressFromPrivateKey();
+
+if (!DEFAULT_OWNER_ADDRESS) {
+  console.error(
+    "[metadata] METADATA_OWNER_PRIVATE_KEY is missing or invalid. Unable to derive owner address."
+  );
+  process.exit(1);
+}
 
 let tokenId = 1;
 
@@ -54,9 +81,15 @@ function generate() {
       .filter((file) => /\.(png|jpg|jpeg|mp4)$/i.test(file));
 
     mediaFiles.forEach((file) => {
-      const metadata = createMetadata(category, file, tokenId);
       const paddedId = String(tokenId).padStart(3, "0");
       const metadataPath = path.join(outputCategoryDir, `${paddedId}.json`);
+      if (fs.existsSync(metadataPath)) {
+        console.log(`⏭ [${category}] Metadata #${tokenId} ${metadataPath} (skipped, already exists)`);
+        tokenId += 1;
+        return;
+      }
+
+      const metadata = createMetadata(category, file, tokenId);
       fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
       console.log(`✔ [${category}] Metadata #${tokenId} ${metadataPath}`);
       tokenId += 1;


### PR DESCRIPTION
## Summary
- derive the default metadata owner address from the METADATA_OWNER_PRIVATE_KEY environment variable using ethers
- abort metadata generation when the owner private key is missing or invalid and preserve existing metadata files on subsequent runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e084c4c9c08333abf3238e308798b5