### PR TITLE
Handle quoted private keys in metadata generation script

### DIFF
--- a/scripts/generateMetadata.cjs
+++ b/scripts/generateMetadata.cjs
@@ -5,7 +5,9 @@ const { Wallet } = require("ethers");
 const ASSETS_DIR = path.join(__dirname, "../public/assets");
 const OUTPUT_DIR = path.join(__dirname, "../metadata");
 const BASE_URL = "https://mint.rahabpunkaholicgirls.com/assets";
-const OWNER_PRIVATE_KEY = (process.env.METADATA_OWNER_PRIVATE_KEY || "").trim();
+const OWNER_PRIVATE_KEY = (process.env.METADATA_OWNER_PRIVATE_KEY || "")
+  .trim()
+  .replace(/^['"]+|['"]+$/g, "");
 
 function resolveOwnerAddressFromPrivateKey() {
   if (!OWNER_PRIVATE_KEY) {


### PR DESCRIPTION
## Summary
- strip surrounding quotes from METADATA_OWNER_PRIVATE_KEY before attempting to derive the wallet address
- prevent valid keys stored with shell-style quotes from being rejected during metadata generation

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0898dd044833392cd36a7ee3558e7