### PR TITLE
Fix metadata contract address handling and button state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,40 @@ import PaymentNFT from "./ui/PaymentNFT";
 type Item = { fileName: string; metadata: any };
 type MetaDict = Record<string, Item[]>;
 
-      }
+const normalizeAddress = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    return ethers.getAddress(trimmed);
+  } catch {
+    return trimmed;
+  }
+};
+
+const getContractAddress = (metadata: any): string => {
+  if (!metadata || typeof metadata !== "object") {
+    return "";
+  }
+
+  const candidates: unknown[] = [
+    metadata.contractAddress,
+    metadata.contract_address,
+    metadata.contract?.address,
+    metadata.address,
+    metadata.collection?.address,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeAddress(candidate);
+    if (normalized) {
+      return normalized;
     }
   }
 

--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -639,15 +639,40 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     if (!activePrice) return "No Price";
     if (isOwner) return "Owner Wallet";
     return "Mint";
+  }, [
+    minting,
+    provider,
+    account,
+    normalizedNftAddress,
+    contractStatus,
+    isSoldOut,
+    mintStatus,
+    activePrice,
+    isOwner,
+  ]);
 
   const isDisabled = useMemo(
     () =>
       minting ||
       !provider ||
       !account ||
+      !normalizedNftAddress ||
+      contractStatus !== "ready" ||
       mintStatus !== LISTED_STATUS ||
       !activePrice ||
       isSoldOut ||
+      isOwner,
+    [
+      minting,
+      provider,
+      account,
+      normalizedNftAddress,
+      contractStatus,
+      mintStatus,
+      activePrice,
+      isSoldOut,
+      isOwner,
+    ]
   );
 
   return (


### PR DESCRIPTION
## Summary
- normalize contract addresses from metadata and fall back across common fields
- disable mint actions unless the wallet, contract address, and listing are ready

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0c60264908333b2eb08de2e0b92f9