### PR TITLE
Fix build failure caused by BigInt literal

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -448,7 +448,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
         normalizedNftAddress
       );
       if (allowance < parsedPrice) {
-        if (allowance > 0n) {
+        if (allowance > BigInt(0)) {
           // Some ERC-20 contracts (e.g., USDT-style) require setting the allowance
           // to zero before increasing it. Mobile wallets on Rahab return a
           // "missing revert data" error otherwise.


### PR DESCRIPTION
## Summary
- replace the BigInt literal used in the allowance reset logic with BigInt(0) so builds targeting below ES2020 succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0da69bed48333a237d57bc877c155