### PR TITLE
Fix PGirls token transfer revert by using SafeERC20

### DIFF
--- a/contracts/PGirlsNFT.sol
+++ b/contracts/PGirlsNFT.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PGirlsNFT is ERC721URIStorage, Ownable {
+    using SafeERC20 for IERC20;
+
     IERC20 public pgirlsToken;
     address public treasury;
     uint256 public nextTokenId;
@@ -21,10 +24,7 @@ contract PGirlsNFT is ERC721URIStorage, Ownable {
     }
 
     function mint(uint256 price, string memory tokenURI) public {
-        require(
-            pgirlsToken.transferFrom(msg.sender, treasury, price),
-            "Payment failed"
-        );
+        pgirlsToken.safeTransferFrom(msg.sender, treasury, price);
 
         uint256 tokenId = nextTokenId;
         _safeMint(msg.sender, tokenId);


### PR DESCRIPTION
## Summary
- switch the PGirlsNFT contract to use OpenZeppelin's SafeERC20 helper
- allow mint payments to work with ERC-20 implementations that don't return a boolean

## Testing
- npx hardhat compile *(fails: Unable to download Solidity compiler because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1043b718c8333b02e9131eda2ada5