### PR TITLE
Prevent contract status from showing errors before wallet availability

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -254,9 +254,16 @@ export default function PaymentNFT(props: PaymentNFTProps) {
 
     (async () => {
       try {
-        if (!provider || !normalizedNftAddress) {
+        if (!normalizedNftAddress) {
           if (!cancelled) {
             setContractStatus("missing");
+          }
+          return;
+        }
+
+        if (!provider) {
+          if (!cancelled) {
+            setContractStatus("unknown");
           }
           return;
         }


### PR DESCRIPTION
## Summary
- keep the NFT contract status as unknown until a provider is available instead of marking it missing
- avoid showing "Contract Unavailable" on initial load when a wallet/provider has not yet been injected

## Testing
- npm run lint *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e1098145288333833b843724554ef2