### PR TITLE
Read contract addresses from metadata props on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,66 @@
 import React, { useEffect, useMemo, useState } from "react";
 import PaymentNFT from "./ui/PaymentNFT";
 
+type MetadataRecord = Record<string, unknown>;
+
+const DEFAULT_NFT_CONTRACT = "0x704Bf56A89c745e6A62C70803816E83b009d2211";
+const DEFAULT_ERC20_CONTRACT = "0x654f25F2a36997C397Aad8a66D5a8783b6E61b9b";
+
+const ADDRESS_KEYS = {
+  nft: [
+    "nftContractAddr",
+    "nftContractAddress",
+    "contractAddress",
+    "collectionAddress",
+    "nftAddress",
+    "collection",
+    "address",
+  ],
+  erc20: [
+    "erc20Address",
+    "pgirlsTokenAddress",
+    "tokenAddress",
+    "paymentTokenAddress",
+    "pgirlsToken",
+    "paymentToken",
+    "token",
+  ],
+} as const;
+
+const isRecord = (value: unknown): value is MetadataRecord =>
+  typeof value === "object" && value !== null;
+
+const getMetadataProps = (metadata: unknown): MetadataRecord => {
+  if (!isRecord(metadata)) {
+    return {};
+  }
+  const props = (metadata as MetadataRecord)["props"];
+  return isRecord(props) ? (props as MetadataRecord) : {};
+};
+
+const pickAddressFromMetadata = (
+  metadata: unknown,
+  keys: readonly string[],
+  fallback?: string
+) => {
+  const metaRecord = isRecord(metadata) ? metadata : {};
+  const props = getMetadataProps(metadata);
+
+  for (const key of keys) {
+    const propValue = props[key];
+    if (typeof propValue === "string" && propValue.trim()) {
+      return propValue.trim();
+    }
+
+    const directValue = metaRecord[key];
+    if (typeof directValue === "string" && directValue.trim()) {
+      return directValue.trim();
+    }
+  }
+
+  return fallback ?? "";
+};
+
 type Item = { fileName: string; metadata: any };
 type MetaDict = Record<string, Item[]>;
 
@@ -132,30 +192,43 @@ export default function RahabMintSite() {
             >
               {cat}
             </h2>
-            {nfts[cat]?.map(({ fileName, metadata }, i) => (
-              <div key={`${cat}-${fileName}`} style={{ marginBottom: "2rem" }}>
-                <PaymentNFT
-                  nftContractAddr={"0x704Bf56A89c745e6A62C70803816E83b009d2211"}
-                  erc20Address={"0x654f25F2a36997C397Aad8a66D5a8783b6E61b9b"}
-                  tokenId={BigInt((starts[cat] ?? 1) + i)}
-                  mediaUrl={metadata.image || metadata.animation_url}
-                  price={(metadata.price ?? "")
-                    .toString()
-                    .replace(/[^\d.]/g, "")}
-                  category={cat}
-                  fileName={fileName}
-                  langStr="en-US"
-                  initialSoldout={Boolean(metadata.soldout)}
-                  initialMintStatus={(metadata.mintStatus ?? "BeforeList") as string}
-                  ownerAddress={
-                    (metadata.ownerAddress ||
-                      metadata.owner ||
-                      metadata.walletAddress ||
-                      "") as string
-                  }
-                />
-              </div>
-            ))}
+            {nfts[cat]?.map(({ fileName, metadata }, i) => {
+              const nftContractAddr = pickAddressFromMetadata(
+                metadata,
+                ADDRESS_KEYS.nft,
+                DEFAULT_NFT_CONTRACT
+              );
+              const erc20Address = pickAddressFromMetadata(
+                metadata,
+                ADDRESS_KEYS.erc20,
+                DEFAULT_ERC20_CONTRACT
+              );
+
+              return (
+                <div key={`${cat}-${fileName}`} style={{ marginBottom: "2rem" }}>
+                  <PaymentNFT
+                    nftContractAddr={nftContractAddr}
+                    erc20Address={erc20Address || undefined}
+                    tokenId={BigInt((starts[cat] ?? 1) + i)}
+                    mediaUrl={(metadata as any).image || (metadata as any).animation_url}
+                    price={((metadata as any).price ?? "")
+                      .toString()
+                      .replace(/[^\d.]/g, "")}
+                    category={cat}
+                    fileName={fileName}
+                    langStr="en-US"
+                    initialSoldout={Boolean((metadata as any).soldout)}
+                    initialMintStatus={((metadata as any).mintStatus ?? "BeforeList") as string}
+                    ownerAddress={
+                      ((metadata as any).ownerAddress ||
+                        (metadata as any).owner ||
+                        (metadata as any).walletAddress ||
+                        "") as string
+                    }
+                  />
+                </div>
+              );
+            })}
           </div>
         ))}
       </section>

--- a/scripts/generateMetadata.cjs
+++ b/scripts/generateMetadata.cjs
@@ -5,7 +5,9 @@ const { Wallet } = require("ethers");
 const ASSETS_DIR = path.join(__dirname, "../public/assets");
 const OUTPUT_DIR = path.join(__dirname, "../metadata");
 const BASE_URL = "https://mint.rahabpunkaholicgirls.com/assets";
-const OWNER_PRIVATE_KEY = (process.env.METADATA_OWNER_PRIVATE_KEY || "")
+const OWNER_PRIVATE_KEY = (
+  process.env.OWNER_PRIVATE_KEY || process.env.METADATA_OWNER_PRIVATE_KEY || ""
+)
   .trim()
   .replace(/^['"]+|['"]+$/g, "");
 
@@ -30,7 +32,7 @@ const DEFAULT_OWNER_ADDRESS = resolveOwnerAddressFromPrivateKey();
 
 if (!DEFAULT_OWNER_ADDRESS) {
   console.error(
-    "[metadata] METADATA_OWNER_PRIVATE_KEY is missing or invalid. Unable to derive owner address."
+    "[metadata] OWNER_PRIVATE_KEY (or METADATA_OWNER_PRIVATE_KEY) is missing or invalid. Unable to derive owner address."
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- allow the metadata generation script to read the owner private key from OWNER_PRIVATE_KEY as well as METADATA_OWNER_PRIVATE_KEY
- clarify the error message to mention both supported environment variables
- load the NFT and PGirls token contract addresses for each listing from metadata props instead of hard-coded values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e08c07bdb8833386cdede87042b11e