### PR TITLE
Fix CREATE2 deployment args for PGirls NFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Deployment helpers expect the following variables to be available (for example i
 
 - `CREATE2_DEPLOYER` / `NEXT_PUBLIC_FACTORY` – address of the CREATE2 factory contract.
 - `NEXT_PUBLIC_NFT_OWNER` / `TREASURY_ADDRESS` – default owner/treasury that will receive mint proceeds.
+- `PGIRLS_ERC20_ADDRESS` / `NEXT_PUBLIC_PGIRLS_ERC20_ADDRESS` – ERC20 token used for minting payments.
 - `RPC_URL` – JSON-RPC endpoint for the PGirls chain.
 - `PRIVATE_KEY` – the account that signs deployment transactions.
 


### PR DESCRIPTION
## Summary
- load environment files directly inside generateMetadata.cjs and resolve the metadata owner address from OWNER_PRIVATE_KEY
- require ERC20 and treasury addresses when generating CREATE2 scripts and encode the constructor arguments with the correct addresses
- document the new PGirls ERC20 environment variable requirement in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e181463e7c83338c227abf51d5c425