### PR TITLE
Pass provider state to PaymentNFT

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -469,6 +469,8 @@ export default function RahabMintSite() {
                         (metadata as any).walletAddress ||
                         "") as string
                     }
+                    provider={provider}
+                    account={account}
                   />
                 </div>
               );


### PR DESCRIPTION
## Summary
- pass the page-level provider and account state down to the PaymentNFT component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1862fd8088333bd13c735deb06c26