### PR TITLE
Improve allowance error guidance

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -171,6 +171,16 @@ function getFriendlyErrorMessage(error: any): string {
     return "Insufficient PGirls token balance (insufficient funds error).";
   }
 
+  const matchesAllowanceReset = ALLOWANCE_RESET_PATTERNS.some((pattern) =>
+    normalized.includes(pattern)
+  );
+  if (matchesAllowanceReset) {
+    return (
+      "Approval failed. Please reset the PGirls token allowance to 0 in " +
+      "your wallet and then try approving again before minting."
+    );
+  }
+
   return raw;
 }
 


### PR DESCRIPTION
## Summary
- clarify the Mint error handling message when wallets report missing revert data
- instruct users to reset the PGirls token allowance to 0 before reapproving

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e23162e2448333b9e840e45974961c