### PR TITLE
Center layout and show contract details

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -313,11 +313,14 @@ export default function RahabMintSite() {
   return (
     <main
       style={{
-        padding: "2rem",
+        padding: "2rem 1.25rem",
         fontFamily: "sans-serif",
         color: "white",
         background: "black",
         minHeight: "100vh",
+        maxWidth: "520px",
+        margin: "0 auto",
+        boxSizing: "border-box",
       }}
     >
       {/* ===== Sticky Header (Title + Links) ===== */}
@@ -328,20 +331,22 @@ export default function RahabMintSite() {
           top: 0,
           zIndex: 1000,
           background: "black",
-          padding: "1rem 0.5rem",
+          padding: "1.25rem 0.5rem 1rem",
           borderBottom: "1px solid #222",
           minHeight: "130px",
           boxSizing: "border-box",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "0.75rem",
         }}
       >
         <div
           style={{
-            position: "absolute",
-            top: "1rem",
-            right: "1rem",
             display: "flex",
+            flexDirection: "column",
             alignItems: "center",
-            gap: "0.5rem",
+            gap: "0.35rem",
           }}
         >
           {account && (
@@ -359,12 +364,13 @@ export default function RahabMintSite() {
             onClick={handleWalletButtonClick}
             disabled={walletButtonDisabled}
             style={{
-              padding: "0.35rem 0.85rem",
+              padding: "0.4rem 1.25rem",
               borderRadius: "999px",
               border: "1px solid #8ecbff",
               background: walletButtonDisabled ? "#222" : "transparent",
               color: "#8ecbff",
               cursor: walletButtonDisabled ? "not-allowed" : "pointer",
+              fontSize: "0.95rem",
             }}
           >
             {walletButtonText}
@@ -378,7 +384,7 @@ export default function RahabMintSite() {
             justifyContent: "center",
             gap: "1rem",
             flexWrap: "wrap",
-            marginBottom: "0.75rem",
+            marginBottom: "0.25rem",
           }}
         >
           <a
@@ -423,6 +429,7 @@ export default function RahabMintSite() {
           alignItems: "center",
           gap: "3rem",
           paddingTop: "1rem",
+          width: "100%",
         }}
       >
         {categories.map((cat) => (

--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -76,12 +76,15 @@ function AutoMedia({
     return (
       <video
         src={url}
-        width={width}
         controls
         loop
         playsInline
         onError={onError}
-        style={{ borderRadius: 12 }}
+        style={{
+          borderRadius: 12,
+          width: "100%",
+          maxWidth: width,
+        }}
       />
     );
   }
@@ -90,8 +93,11 @@ function AutoMedia({
     <img
       src={url}
       alt="NFT Preview"
-      width={width}
-      style={{ borderRadius: 12 }}
+      style={{
+        borderRadius: 12,
+        width: "100%",
+        maxWidth: width,
+      }}
       onError={onError}
       onContextMenu={(e) => e.preventDefault()}
       draggable={false}
@@ -825,8 +831,26 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     ]
   );
 
+  const formattedTokenId = useMemo(() => tokenId.toString(), [tokenId]);
+  const displayNftAddress = useMemo(
+    () => normalizedNftAddress || "-",
+    [normalizedNftAddress]
+  );
+
   return (
-    <div style={{ textAlign: "center" }}>
+    <div
+      style={{
+        textAlign: "center",
+        background: "#101010",
+        borderRadius: "20px",
+        padding: "1.25rem",
+        width: "100%",
+        maxWidth: "420px",
+        margin: "0 auto",
+        boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+        boxSizing: "border-box",
+      }}
+    >
       <AutoMedia providedUrl={mediaUrl} category={category} fileName={fileName} />
 
       <p style={{ fontSize: "0.9rem", color: "#ccc" }}>
@@ -876,11 +900,10 @@ export default function PaymentNFT(props: PaymentNFTProps) {
           verifying the metadata.
         </p>
       )}
-      {tokenStatus === "resolved" && tokenAddr && (
-        <p style={{ fontSize: "0.8rem", color: "#ccc" }}>
-          PGirls token: {tokenAddr}
-        </p>
-      )}
+      <p style={{ fontSize: "0.8rem", color: "#ccc", wordBreak: "break-all" }}>
+        NFT Contract: {displayNftAddress}
+      </p>
+      <p style={{ fontSize: "0.8rem", color: "#ccc" }}>Token ID: {formattedTokenId}</p>
 
       {!isSoldOut && (
         <div
@@ -948,7 +971,12 @@ export default function PaymentNFT(props: PaymentNFTProps) {
 
       {txHash && (
         <p
-          style={{ marginTop: "0.5rem", fontSize: "0.85em", color: "lightgreen" }}
+          style={{
+            marginTop: "0.5rem",
+            fontSize: "0.85em",
+            color: "lightgreen",
+            wordBreak: "break-all",
+          }}
         >
           Tx Hash:{" "}
           <a


### PR DESCRIPTION
## Summary
- center the mint page layout to match the requested mobile-focused design
- restyle the NFT card container for a compact centered presentation and show NFT contract/token ID information
- keep transaction hashes readable with automatic wrapping

## Testing
- `npm run lint` *(fails: prompts for initial ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23b11d3f8833382eabc52b4301e54