### PR TITLE
Allow owners to manage sold listings

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -697,9 +697,13 @@ export default function PaymentNFT(props: PaymentNFTProps) {
 
   const canList = useMemo(() => {
     if (!isOwner) return false;
-    if (isSoldOut) return false;
     return true;
-  }, [isOwner, isSoldOut]);
+  }, [isOwner]);
+
+  const shouldShowListingControls = useMemo(() => {
+    if (canList) return true;
+    return !isSoldOut;
+  }, [canList, isSoldOut]);
 
   const disableListingButton = useMemo(() => {
     if (updatingListing || !canList) return true;
@@ -787,10 +791,10 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     if (contractStatus === "missing") return "Contract Unavailable";
     if (tokenStatus === "resolving") return "Resolving Token";
     if (tokenStatus === "missing") return "Token Unavailable";
+    if (isOwner) return "Owner Wallet";
     if (isSoldOut) return "Sold Out";
     if (mintStatus !== LISTED_STATUS) return "Not Listed";
     if (!activePrice) return "No Price";
-    if (isOwner) return "Owner Wallet";
     return "Mint";
     }, [
       minting,
@@ -905,7 +909,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
       </p>
       <p style={{ fontSize: "0.8rem", color: "#ccc" }}>Token ID: {formattedTokenId}</p>
 
-      {!isSoldOut && (
+      {shouldShowListingControls && (
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
## Summary
- ensure connected owner wallets keep access to the listing controls even if the NFT was previously detected as sold out
- show an "Owner Wallet" state on the mint button instead of "Sold Out" when the owner is connected

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e24016245483339d3dcce205e89af0