### PR TITLE
Fix resale listings showing sold out

### DIFF
--- a/app/api/updateListing/route.ts
+++ b/app/api/updateListing/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 const METADATA_DIR = path.join(process.cwd(), "metadata");
 const DEFAULT_MINT_STATUS = "BeforeList";
+const LISTED_STATUS = "Listed";
 
 function normalizeOwner(ownerAddress: unknown) {
   if (typeof ownerAddress === "string") {
@@ -43,10 +44,16 @@ export async function POST(request: Request) {
 
     const data = await loadMetadata(filePath);
 
+    let normalizedMintStatus: string | undefined;
+
     if (typeof mintStatus === "string" && mintStatus.trim()) {
-      data.mintStatus = mintStatus.trim();
+      normalizedMintStatus = mintStatus.trim();
+      data.mintStatus = normalizedMintStatus;
     } else if (!data.mintStatus) {
       data.mintStatus = DEFAULT_MINT_STATUS;
+      normalizedMintStatus = data.mintStatus;
+    } else if (typeof data.mintStatus === "string") {
+      normalizedMintStatus = data.mintStatus;
     }
 
     if (typeof price !== "undefined") {
@@ -57,6 +64,10 @@ export async function POST(request: Request) {
       } else {
         delete data.price;
       }
+    }
+
+    if ((normalizedMintStatus ?? data.mintStatus) === LISTED_STATUS) {
+      data.soldout = false;
     }
 
     if (typeof ownerAddress !== "undefined") {

--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -424,12 +424,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   const checkSoldOut = useCallback(async () => {
     try {
       if (mintStatus !== LISTED_STATUS) {
-        setIsSoldOut(false);
-        return;
-      }
-
-      if (initialSoldout) {
-        setIsSoldOut(true);
+        setIsSoldOut(Boolean(initialSoldout));
         return;
       }
       if (
@@ -470,9 +465,9 @@ export default function PaymentNFT(props: PaymentNFTProps) {
     provider,
     normalizedNftAddress,
     tokenId,
-    initialSoldout,
     mintStatus,
     contractStatus,
+    initialSoldout,
   ]);
 
   useEffect(() => {
@@ -761,6 +756,9 @@ export default function PaymentNFT(props: PaymentNFTProps) {
       setMintStatus(nextStatus);
       setActivePrice(nextPrice);
       setListPriceInput(nextPrice);
+      if (willList) {
+        setIsSoldOut(false);
+      }
       if (nextOwner) {
         setCurrentOwnerAddress(nextOwner);
       }


### PR DESCRIPTION
## Summary
- keep metadata soldout flag cleared whenever a listing is created again
- ensure the mint button no longer treats prior soldout metadata as blocking resale listings
- reset the local sold-out state immediately after relisting an item

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e244ccd7448333b8d7ffd521df5a60