### PR TITLE
Add ERC2981 royalty support to PGirlsNFT

### DIFF
--- a/contracts/PGirlsNFT.sol
+++ b/contracts/PGirlsNFT.sol
@@ -2,16 +2,21 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/token/common/ERC2981.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract PGirlsNFT is ERC721URIStorage, Ownable {
+contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
     using SafeERC20 for IERC20;
 
     IERC20 public pgirlsToken;
     address public treasury;
     uint256 public nextTokenId;
+
+    address private constant CREATOR_ADDRESS =
+        0xfF280ED2B0FF2Fb64E97137F82307042B4338C79;
+    uint96 private constant ROYALTY_BPS = 500; // 5%
 
     constructor(
         address initialOwner,
@@ -21,6 +26,8 @@ contract PGirlsNFT is ERC721URIStorage, Ownable {
         pgirlsToken = IERC20(_pgirlsToken);
         treasury = _treasury;
         nextTokenId = 1;
+
+        _setDefaultRoyalty(CREATOR_ADDRESS, ROYALTY_BPS);
     }
 
     function mint(uint256 price, string memory tokenURI) public {
@@ -35,5 +42,14 @@ contract PGirlsNFT is ERC721URIStorage, Ownable {
 
     function updateTokenURI(uint256 tokenId, string memory newURI) public onlyOwner {
         _setTokenURI(tokenId, newURI);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721, ERC2981)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## Summary
- integrate OpenZeppelin ERC2981 royalties into PGirlsNFT
- set a 5% default royalty directed to 0xfF280ED2B0FF2Fb64E97137F82307042B4338C79
- ensure ERC2981 interface detection via supportsInterface override

## Testing
- `npx hardhat compile` *(fails: Hardhat cannot download the compiler because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24e38b2488333a6bbcda7e45130e6