### PR TITLE
Adjust TypeScript target to ES2020 for BigInt literals

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- raise the TypeScript compiler target to ES2020 so BigInt literals compile successfully

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25dd946f88333b390f6dacd43024d