### PR TITLE
Fix supportsInterface override to reference ERC721URIStorage

### DIFF
--- a/contracts/PGirlsNFT.sol
+++ b/contracts/PGirlsNFT.sol
@@ -55,7 +55,7 @@ contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(ERC721, ERC2981)
+        override(ERC721URIStorage, ERC2981)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);


### PR DESCRIPTION
## Summary
- fix the supportsInterface override to refer to ERC721URIStorage alongside ERC2981 so the contract compiles

## Testing
- npx hardhat compile *(fails: HH502 couldn't download compiler version list due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b3f3b8f483339161a2aa41c652b7