### PR TITLE
Improve contract checks and hide PGirlsChain switch prompt

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -665,23 +665,7 @@ export default function RahabMintSite() {
           >
             {walletButtonText}
           </button>
-          {hasProvider && !networkOk && (
-            <button
-              onClick={switchNetworkManually}
-              style={{
-                marginTop: "6px",
-                padding: "0.35rem 1rem",
-                borderRadius: 999,
-                border: "1px solid #ff9c9c",
-                background: "transparent",
-                color: "#ff9c9c",
-                cursor: "pointer",
-                fontSize: "0.9rem",
-              }}
-            >
-              Switch to {CHAIN_NAME}
-            </button>
-          )}
+          {/* ネットワーク切り替えは必須ではないため、案内ボタンは表示しない */}
         </div>
         {/* Title + Get PGirls (横並び&中央寄せ) */}
         <div


### PR DESCRIPTION
## Summary
- hide the manual "Switch to PGirlsChain" prompt because the dapp no longer requires forcing that network
- add a shared fallback RPC provider so NFT/token contracts can be resolved even when the injected wallet stays on another chain
- reuse the fallback provider for allowance, balance, and status checks to prevent spurious contract-missing errors

## Testing
- npm run lint *(fails: Next.js prompts for initial ESLint configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e5f9c1d48333b4bd0ce31b24eb5f