### PR TITLE
Fix provider list construction to avoid type mismatch

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -264,12 +264,10 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   const fallbackProvider = useMemo(() => getFallbackProvider(), []);
 
   const readProviders = useMemo(() => {
-    const list: ethers.Provider[] = [];
-    if (provider) list.push(provider);
-    if (fallbackProvider && fallbackProvider !== provider) {
-      list.push(fallbackProvider);
-    }
-    return list;
+    const list = new Set<ethers.Provider>();
+    if (provider) list.add(provider);
+    if (fallbackProvider) list.add(fallbackProvider);
+    return Array.from(list);
   }, [provider, fallbackProvider]);
 
   const primaryReadProvider = readProviders[0] ?? null;


### PR DESCRIPTION
## Summary
- prevent the read provider list from comparing BrowserProvider and JsonRpcProvider directly by using a Set to handle deduplication

## Testing
- not run (next lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e2e9ac64408333a57bcaf978426c5c