### PR TITLE
Replace PGirlsNFT contract with updated royalty handling

### DIFF
--- a/contracts/PGirlsNFT.sol
+++ b/contracts/PGirlsNFT.sol
@@ -11,11 +11,17 @@ contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
     using SafeERC20 for IERC20;
 
     IERC20 public pgirlsToken;
+
+    /**
+     * 販売者の受取先。一次販売時の95%の受け取り先として利用します。
+     * （運用では販売者のウォレット＝Panchan などを指定）
+     */
     address public treasury;
+
     uint256 public nextTokenId;
 
-    address private constant CREATOR_ADDRESS =
-        0xfF280ED2B0FF2Fb64E97137F82307042B4338C79;
+    // 既定のロイヤリティ受取先（Rahab）: 5% (500 bps)
+    address private constant CREATOR_ADDRESS = 0xfF280ED2B0FF2Fb64E97137F82307042B4338C79;
     uint96 private constant ROYALTY_BPS = 500; // 5%
 
     constructor(
@@ -27,17 +33,28 @@ contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
         treasury = _treasury;
         nextTokenId = 1;
 
+        // 既定のロイヤリティ設定（全トークンに適用）
         _setDefaultRoyalty(CREATOR_ADDRESS, ROYALTY_BPS);
     }
 
-    function mint(uint256 price, string memory tokenURI) public {
-        _purchase(price, tokenURI);
+    /* -----------------------------
+       一次販売
+       price の 5% をロイヤリティ受取先（Rahab）へ、
+       残り 95% を treasury（販売者）へ送金します。
+    ------------------------------*/
+    function mint(uint256 price, string memory tokenURI) external {
+        _purchasePrimary(price, tokenURI);
     }
 
     function buy(uint256 price, string memory tokenURI) external {
-        _purchase(price, tokenURI);
+        _purchasePrimary(price, tokenURI);
     }
 
+    /* -----------------------------
+       二次販売
+       ERC2981 の royaltyInfo を使用してロイヤリティを算出し、
+       残りを seller へ送金します。
+    ------------------------------*/
     function buySecondary(uint256 tokenId, uint256 price) external {
         require(price > 0, "Invalid price");
         require(_exists(tokenId), "Nonexistent token");
@@ -45,29 +62,55 @@ contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
         address seller = ownerOf(tokenId);
         require(seller != msg.sender, "Already the owner");
 
-        uint256 royaltyShare = (price * ROYALTY_BPS) / _feeDenominator();
-        uint256 sellerShare = price - royaltyShare;
+        (address royaltyReceiver, uint256 royaltyAmount) = royaltyInfo(tokenId, price);
+        uint256 sellerAmount = price - royaltyAmount;
 
-        pgirlsToken.safeTransferFrom(msg.sender, seller, sellerShare);
-        pgirlsToken.safeTransferFrom(msg.sender, owner(), royaltyShare);
+        // 送金順序は任意。allowance はUI側で事前にapprove済み想定
+        if (royaltyAmount > 0) {
+            pgirlsToken.safeTransferFrom(msg.sender, royaltyReceiver, royaltyAmount);
+        }
+        pgirlsToken.safeTransferFrom(msg.sender, seller, sellerAmount);
 
         _safeTransfer(seller, msg.sender, tokenId, "");
     }
 
-    function _purchase(uint256 price, string memory tokenURI) internal {
-        pgirlsToken.safeTransferFrom(msg.sender, treasury, price);
+    /* -----------------------------
+       内部: 一次販売の購入処理
+    ------------------------------*/
+    function _purchasePrimary(uint256 price, string memory tokenURI) internal {
+        require(price > 0, "Invalid price");
+        require(treasury != address(0), "Treasury not set");
 
         uint256 tokenId = nextTokenId;
+
+        // まだミント前でも defaultRoyalty が有効なので tokenId を使って royaltyInfo を参照可
+        (address royaltyReceiver, uint256 royaltyAmount) = royaltyInfo(tokenId, price);
+        uint256 sellerAmount = price - royaltyAmount;
+
+        if (royaltyAmount > 0) {
+            pgirlsToken.safeTransferFrom(msg.sender, royaltyReceiver, royaltyAmount);
+        }
+        pgirlsToken.safeTransferFrom(msg.sender, treasury, sellerAmount);
+
         _safeMint(msg.sender, tokenId);
         _setTokenURI(tokenId, tokenURI);
 
         nextTokenId += 1;
     }
 
-    function updateTokenURI(uint256 tokenId, string memory newURI) public onlyOwner {
+    /* -----------------------------
+       管理系
+    ------------------------------*/
+    function updateTokenURI(uint256 tokenId, string memory newURI) external onlyOwner {
         _setTokenURI(tokenId, newURI);
     }
 
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "zero address");
+        treasury = newTreasury;
+    }
+
+    // OZ の multiple inheritance に合わせた supportsInterface
     function supportsInterface(bytes4 interfaceId)
         public
         view


### PR DESCRIPTION
## Summary
- replace the PGirlsNFT contract with the updated implementation that splits primary sales between the treasury and the default royalty recipient
- leverage ERC2981 royaltyInfo for secondary sales payouts and add treasury management helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33b6138a88333816d1767325ed9db