### PR TITLE
Fix secondary sale existence check for OZ v5 compatibility

### DIFF
--- a/contracts/PGirlsNFT.sol
+++ b/contracts/PGirlsNFT.sol
@@ -57,7 +57,7 @@ contract PGirlsNFT is ERC721URIStorage, ERC2981, Ownable {
     ------------------------------*/
     function buySecondary(uint256 tokenId, uint256 price) external {
         require(price > 0, "Invalid price");
-        require(_exists(tokenId), "Nonexistent token");
+        _requireOwned(tokenId);
 
         address seller = ownerOf(tokenId);
         require(seller != msg.sender, "Already the owner");


### PR DESCRIPTION
## Summary
- replace the removed `_exists` check with `_requireOwned` in the secondary sale flow to match OpenZeppelin v5 APIs

## Testing
- `npx hardhat compile` *(fails: HardhatError HH502 because the Solidity compiler version list could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33c22bfe0833388ede8f85a359456