### PR TITLE
Read token id from metadata

### DIFF
--- a/app/ui/PaymentNFT.tsx
+++ b/app/ui/PaymentNFT.tsx
@@ -53,6 +53,7 @@ async function silentlyWatchAsset(eth: any, tokenAddr?: string, decimals?: numbe
 export interface PaymentNFTProps {
   nftContractAddr: string;
   tokenId: bigint;
+  tokenIdLabel?: string;
 
   /** 明示アドレス（pgirlsToken() が読めない場合のフォールバック） */
   erc20Address?: string;
@@ -200,6 +201,7 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   const {
     nftContractAddr,
     tokenId,
+    tokenIdLabel,
     erc20Address,
     langStr,
     mediaUrl,
@@ -888,7 +890,16 @@ export default function PaymentNFT(props: PaymentNFTProps) {
   );
 
   /* ---------- Render ---------- */
-  const formattedTokenId = useMemo(() => tokenId.toString(), [tokenId]);
+  const formattedTokenId = useMemo(() => {
+    if (typeof tokenIdLabel === "string" && tokenIdLabel.trim()) {
+      return tokenIdLabel.trim();
+    }
+    try {
+      return tokenId.toString();
+    } catch {
+      return "";
+    }
+  }, [tokenIdLabel, tokenId]);
   const displayNftAddress = useMemo(() => normalizedNftAddress || "-", [normalizedNftAddress]);
 
   return (


### PR DESCRIPTION
## Summary
- parse token IDs from metadata when building the NFT list
- pass the metadata-provided token ID (and label) into the payment component for display
- fall back to sequential IDs only when metadata is missing a usable value

## Testing
- ⚠️ `npm run lint` *(fails: requires interactive ESLint setup prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e393ac5500833394ec1057eed69dbc